### PR TITLE
Added HTTP timeout handling.

### DIFF
--- a/Telegram.Bot.Library/Extensions/Extensions.cs
+++ b/Telegram.Bot.Library/Extensions/Extensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Telegram.Bot.Library.Extensions
+{
+    public static class Extensions
+    {
+        public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout, CancellationTokenSource taskCTS)
+        {
+            using (var timeoutCTS = new CancellationTokenSource())
+            {
+                var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCTS.Token));
+                if (completedTask == task)
+                {
+                    timeoutCTS.Cancel();
+                    return await task;
+                }
+                else
+                {
+                    taskCTS.Cancel();
+                    throw new TimeoutException("The operation has timed out.");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Simple timeout setting on HTTP client would hide exception and will just show "Task was canceled" so there was new extension created. Extension method TimeoutAfter will also cancel background task after timeout.